### PR TITLE
Fix blocking synchronization issue with expiring notifications.

### DIFF
--- a/src/main/java/com/percero/agents/sync/datastore/RedisCacheDataStore.java
+++ b/src/main/java/com/percero/agents/sync/datastore/RedisCacheDataStore.java
@@ -83,8 +83,6 @@ public class RedisCacheDataStore implements ICacheDataStore {
 		}
 	}
 	
-	
-	@SuppressWarnings("unchecked")
 	private Map<String, PendingExpire> expiresToBeWritten = new ConcurrentHashMap<String, PendingExpire>();
 	/* (non-Javadoc)
 	 * @see com.percero.agents.sync.datastore.IRedisCacheDataStore#postExpires()

--- a/src/main/java/com/percero/agents/sync/datastore/RedisCacheDataStore.java
+++ b/src/main/java/com/percero/agents/sync/datastore/RedisCacheDataStore.java
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.percero.agents.sync.services.PerceroRedisTemplate;
 
-import edu.emory.mathcs.backport.java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class RedisCacheDataStore implements ICacheDataStore {
 
@@ -85,37 +85,25 @@ public class RedisCacheDataStore implements ICacheDataStore {
 	
 	
 	@SuppressWarnings("unchecked")
-	private Map<String, PendingExpire> expiresToBeWritten = Collections.synchronizedMap(new HashMap<String, PendingExpire>());
+	private Map<String, PendingExpire> expiresToBeWritten = new ConcurrentHashMap<String, PendingExpire>();
 	/* (non-Javadoc)
 	 * @see com.percero.agents.sync.datastore.IRedisCacheDataStore#postExpires()
 	 */
 	@Override
 	@Scheduled(fixedRate=600000)	// 10 * 60 * 1000 -> Ten Minutes.
 	public void postExpires() {
-		log.info("Posting " +  expiresToBeWritten.size() + " expire" + (expiresToBeWritten.size() == 1 ? "" : "s"));
-		synchronized (expiresToBeWritten) {
-			Collection<String> expireKeysToRemove = new HashSet<String>(expiresToBeWritten.size(), (float)1.0);
-			Iterator<Map.Entry<String, PendingExpire>> itrExpiresEntrySet = expiresToBeWritten.entrySet().iterator();
-			while (itrExpiresEntrySet.hasNext()) {
-				Map.Entry<String, PendingExpire> nextEntry = itrExpiresEntrySet.next();
-				String nextKey = nextEntry.getKey();
-				PendingExpire nextPendingExpire = nextEntry.getValue();
-				expire(nextPendingExpire.key, nextPendingExpire.timeout, nextPendingExpire.timeUnit, true);
-				expireKeysToRemove.add(nextKey);
-			}
-//			Iterator<String> itrExpires = expiresToBeWritten.keySet().iterator();
-//			while (itrExpires.hasNext()) {
-//				String nextKey = itrExpires.next();
-//				PendingExpire nextPendingExpire = expiresToBeWritten.get(nextKey);
-//				expire(nextPendingExpire.key, nextPendingExpire.timeout, nextPendingExpire.timeUnit, true);
-//				expireKeysToRemove.add(nextKey);
-//			}
-			
-			Iterator<String> itrExpireKeysToRemove = expireKeysToRemove.iterator();
-			while (itrExpireKeysToRemove.hasNext()) {
-				expiresToBeWritten.remove(itrExpireKeysToRemove.next());
+		log.info("Posting  expire(s)..");
+		int expiredCounter = 0;
+		for(String key : expiresToBeWritten.keySet()){
+			PendingExpire nextPendingExpire = expiresToBeWritten.get(key);
+			if (expire(nextPendingExpire.key, nextPendingExpire.timeout, nextPendingExpire.timeUnit, true)) {
+				expiresToBeWritten.remove(key);
+				expiredCounter++;
+			} else {
+				log.error("Failed to expire key: " + key);
 			}
 		}
+		log.info("Expired: " + expiredCounter);
 	}
 	
 	private class PendingExpire {


### PR DESCRIPTION
swapping out the SynchronizedMap used for expires with a ConcurrentHashMap to prevent blocking when adding new expires while old ones are processing.
