### PR TITLE
Whoops. Realized too late why the return value from expires was being dropped.

### DIFF
--- a/src/main/java/com/percero/agents/sync/datastore/RedisCacheDataStore.java
+++ b/src/main/java/com/percero/agents/sync/datastore/RedisCacheDataStore.java
@@ -92,16 +92,18 @@ public class RedisCacheDataStore implements ICacheDataStore {
 	public void postExpires() {
 		log.info("Posting  expire(s)..");
 		int expiredCounter = 0;
+		int failedCounter = 0;
 		for(String key : expiresToBeWritten.keySet()){
 			PendingExpire nextPendingExpire = expiresToBeWritten.get(key);
 			if (expire(nextPendingExpire.key, nextPendingExpire.timeout, nextPendingExpire.timeUnit, true)) {
-				expiresToBeWritten.remove(key);
 				expiredCounter++;
 			} else {
-				log.error("Failed to expire key: " + key);
+				failedCounter++;
 			}
+			expiresToBeWritten.remove(key);
 		}
-		log.info("Expired: " + expiredCounter);
+		log.info("Successully Expired: " + expiredCounter);
+		log.info("Failed to expire: " + failedCounter);
 	}
 	
 	private class PendingExpire {


### PR DESCRIPTION
Abstraction prevents actually using a return value from expire() to figure out what happened, and it's not worth it to do another hit to see if it was a missing key, or some other issue. It seems somewhere in here, the key is getting Deleted, but somehow it's still getting called for expire() as well at some point. Haven't dug deep enough to figure out why something is doing both actions, but for now, we'll just assume they key to be expired is already gone (it was in 100% of the cases I tracked down) and deal with it at a later date, or just let the default Redis TTL deal with it if it's really still there and needs expiring. I changed the logging to show both success and fail count when it runs the cleanup process for now as well, in case it might be interesting or useful to see numbers about how frequently it's deleting _and_ trying to expire the same keys.
